### PR TITLE
fix: distribute install.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "files": [
     "/dist",
-    "/pmd"
+    "/pmd",
+    "/install.js"
   ],
   "license": "BSD",
   "main": "pmd",


### PR DESCRIPTION
Without `install.js` specified in the `files` key, installing `pmd-bin` as a dependency actually fails because it tries to run that as part of installation but it's not included for distribution (oops!). Interesting that this wasn't caught by the CI.

Also, I note that pmd is actually included in the `dist` folder directly from npm. I think installation on the end-user's machine will still trigger a re-download however, which is unnecessary. It'd be good if we could separate the downloading of pmd and the installation of java into separate pieces, because installation of java will still have to occur on the end-user's machine.