### PR TITLE
Couple build fixes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,26 @@
+name: Test released package
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  without-java-installed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: remove java
+        run: |
+          sudo rm -f "$(which java)" "$(which javac)"
+          unset JAVA_HOME
+          java --version || true
+      - name: Install pmd-bin
+        run: npm install --global pmd-bin@${GITHUB_REF#"refs/tags/v"}
+      - name: Run tests
+        run: bash test.sh

--- a/download-pmd.js
+++ b/download-pmd.js
@@ -1,3 +1,8 @@
+async function cleanDist() {
+  const fs = require('fs/promises');
+  return fs.rm("dist", { recursive: true, force: true });
+}
+
 async function downloadPmd() {
   const pmdVer = require("./package.json").pmd.version;
   const url = `https://github.com/pmd/pmd/releases/download/pmd_releases%2F${pmdVer}/pmd-bin-${pmdVer}.zip`;
@@ -23,7 +28,7 @@ async function movePmd() {
 }
 
 async function installPmd() {
-  return downloadPmd().then(extractPmd).then(movePmd);
+  return cleanDist().then(downloadPmd).then(extractPmd).then(movePmd);
 }
 
 async function main() {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "files": [
     "/dist",
     "/pmd",
-    "/install.js"
+    "/download-java.js"
   ],
   "license": "BSD",
   "main": "pmd",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "install": "node download-java.js",
     "build": "node download-pmd.js",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "test": "PATH=\"${PATH}:${PWD}\" bash test.sh"
   }
 }

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ set -eo errexit
 ret=0;
 
 echo -n "it should succeed linting valid apex code... "
-if ! ./pmd -dir ./fixtures/valid -rulesets apex-style -language apex > /dev/null; then
+if ! pmd -dir ./fixtures/valid -rulesets apex-style -language apex > /dev/null; then
     echo "failed"
     ret=1;
 else 
@@ -15,7 +15,7 @@ else
 fi
 
 echo -n "it should fail linting invalid apex code... "
-if ./pmd -dir ./fixtures/invalid -rulesets apex-style -language apex > /dev/null; then
+if pmd -dir ./fixtures/invalid -rulesets apex-style -language apex > /dev/null; then
     echo "failed"
     ret=1;
 else 


### PR DESCRIPTION
* package `download-java.js` after rename from `install.js` (fixes #39)
* rm dist directory before downloading pmd - v1.21.1 published on npm right now has doubled in size due to bundling pmd within both `dist/pmd-bin` and `dist/pmd-bin-${PMD_VER}`