### PR TITLE
feat: the download of Java can be skipped using an environment variable

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -9,19 +9,6 @@ on:
       - master
 
 jobs:
-  with-java-installed:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .node-version
-      - name: Install dependencies
-        run: npm ci
-      - name: Run tests
-        run: npm run test
   without-java-installed:
     runs-on: ubuntu-latest
     steps:
@@ -34,14 +21,51 @@ jobs:
       - name: remove java
         run: |
           sudo rm -f "$(which java)" "$(which javac)"
+          java --version || true
+      - name: Install dependencies
+        run: |
           unset JAVA_HOME
+          npm ci
+      - name: Run tests
+        run: npm run test
+  with-java-installed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+      - name: print java setup
+        run: |
+          echo "JAVA_HOME: $JAVA_HOME"
           java --version || true
       - name: Install dependencies
         run: npm ci
       - name: Run tests
         run: npm run test
+  with-java-installed-skip-java-download:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+      - name: print java setup
+        run: |
+          echo "JAVA_HOME: $JAVA_HOME"
+          java --version || true
+      - name: Install dependencies
+        run: |
+          export PMD_BIN_SKIP_JAVA_DOWNLOAD=true
+          npm ci
+      - name: Run tests
+        run: npm run test
   release:
-    needs: [with-java-installed, without-java-installed]
+    needs: [without-java-installed, with-java-installed, with-java-installed-skip-java-download]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,9 +18,10 @@ jobs:
       - name: remove java
         run: |
           sudo rm -f "$(which java)" "$(which javac)"
-          unset JAVA_HOME
           java --version || true
       - name: Install pmd-bin
-        run: npm install --global pmd-bin@${GITHUB_REF#"refs/tags/v"}
+        run: |
+          unset JAVA_HOME
+          npm install --global pmd-bin@${GITHUB_REF#"refs/tags/v"}
       - name: Run tests
         run: bash test.sh

--- a/download-java.js
+++ b/download-java.js
@@ -14,7 +14,11 @@ async function installJava() {
 }
 
 async function main() {
-  await installJava();
+  if (process.env["PMD_BIN_SKIP_JAVA_DOWNLOAD"] === "true") {
+    console.log("skipped downloading Java");
+  } else {
+    await installJava();
+  }
 }
 
 main();


### PR DESCRIPTION
By default Java is downloaded on installing this package. You can now skip the download and use the system Java by setting the environment variable `PMD_BIN_SKIP_JAVA_DOWNLOAD` to `true`.

Example:

```console
export PMD_BIN_SKIP_JAVA_DOWNLOAD="true"
npm install --global pmd-bin
```

Fixes #95

Co-authored-by: Geoff Swift