### PR TITLE
fix: retain executable bit on pmd binary in linux

### DIFF
--- a/download-pmd.js
+++ b/download-pmd.js
@@ -14,7 +14,7 @@ async function extractPmd(buffer) {
   const Zip = require("adm-zip");
 
   const pmdZip = new Zip(buffer);
-  pmdZip.extractAllTo("dist", true);
+  pmdZip.extractAllTo("dist", true, true);
 }
 
 async function movePmd() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "pmd": "pmd"
       },
       "devDependencies": {
-        "adm-zip": "^0.5.10"
+        "adm-zip": "^0.5.16"
       }
     },
     "node_modules/adm-zip": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node-java-connector": "1.1.1"
   },
   "devDependencies": {
-    "adm-zip": "^0.5.10"
+    "adm-zip": "^0.5.16"
   },
   "files": [
     "/dist",


### PR DESCRIPTION
The extracted `dist/pmd-bin/bin/pmd` file isn't retaining the executable permissions from the zip when extracted using `adm-zip`'s `extractAllTo()` function.

`adm-zip`  allows restoring the file permissions when extracting, but the flag must be passed explicitly.

https://github.com/cthackers/adm-zip/blob/1c7860ff5005cd30bf5dc6e557c9b312fedc0a66/adm-zip.js#L750

The update of `adm-zip` is mostly non-functional due to the `package-lock.json` already specifying that version, but it's probably a Good Idea.